### PR TITLE
Dokumentation: Offline-Testprotokoll hinzugefügt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ Lokales Tool zur Verwaltung von Rückgabefristen & Garantien. Läuft komplett im
 - **Kamera**: für Barcode‑Scan und Foto‑OCR (nur nach expliziter Zustimmung).
 - **Benachrichtigungen**: lokale Reminder; funktionieren nur über **https**.
 - **Datenhaltung**: lokal via IndexedDB. Export/Import als JSON/CSV/ICS möglich.
+
+## Projekt-Log
+
+| Datum (UTC) | Browser | Plattform | Schritt | Ergebnis |
+| --- | --- | --- | --- | --- |
+| 2025-09-19 | Chromium (Playwright, headless) | Linux-Container | Service Worker-Registrierung | ❌ `Failed to register a ServiceWorker: The URL protocol of the script ('blob:…') is not supported.` |
+| 2025-09-19 | Chromium (Playwright, headless) | Linux-Container | OCR (Offline, Beispielbild) | ❌ `Tesseract is not defined` – keine Offline-Bundle für OCR geladen. |
+| 2025-09-19 | Chromium (Playwright, headless) | Linux-Container | ZXing Barcode-Scan (Offline) | ❌ `ZXing`-Namespace nicht verfügbar (Bibliothek nicht offline geladen). |
+| 2025-09-19 | Chromium (Playwright, headless) | Linux-Container | ZIP-Export aus Nachweis-Dialog (Offline) | ❌ Kein Evidence-File im Dialog (`#ev_list` bleibt leer), Export nicht ausgelöst. |


### PR DESCRIPTION
## Summary
- ergänze einen Projekt-Log in der README mit den Ergebnissen der aktuellen Offline-Prüfung (Service Worker, OCR, ZXing, ZIP-Export)

## Testing
- manuelle Playwright-Session zur Offline-Prüfung (Service-Worker-Registrierung, OCR, ZXing, ZIP-Export)


------
https://chatgpt.com/codex/tasks/task_e_68cccb9ca2e48332a688c1c0270f7474